### PR TITLE
Update PKGBUILD to add qt5-networkauth dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,7 @@ depends=(
   'qt5-base'
   'qt5-webengine'
   'qt5-x11extras'
+  'qt5-networkauth'
   'openssl'
   'poco'
   'lua'


### PR DESCRIPTION
Hey, thanks for putting the PKGBUILD together. My build failed because I was missing the above package. Succeeded after adding it.