### PR TITLE
Add dependency on qt5-networkauth

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,6 +15,7 @@ license=('BSD')
 depends=(
   'libxss'
   'qt5-base'
+  'qt5-networkauth'
   'qt5-webengine'
   'qt5-x11extras'
   'openssl'


### PR DESCRIPTION
I was not able to install this package without first installing `qt5-networkauth` from the extras repository. I'm not sure if this is often included by default by other packages, but at least on my system it was not installed.